### PR TITLE
Add caching and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+pytest_cache/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,3 +2,6 @@
 
 - Initialized instructions for Codex in `AGENTS.md`.
 - Updated instructions for local development, GPT-4.1mini model, and environment variables.
+- Added project skeleton `mvp-medical-app` with Streamlit app, modules, and Docker setup.
+- Implemented caching and layout improvements for image analysis page.
+- Added unit tests for analysis and report modules.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# kyotoyama
+# Kyotoyama Medical Image Analyzer
+
+This repository contains an MVP for a Streamlit-based medical image analysis application.
+The project follows the plan outlined in `GoogleクラウドMRI病変検出MVP開発案_.md`.
+
+The application allows users to upload medical images, perform segmentation with ANTsPyNet,
+and generate a structured report using the Gemini API.
+
+## Development
+
+Create a Python 3.11 virtual environment and install dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r mvp-medical-app/requirements.txt
+```
+
+Run the Streamlit app:
+
+```bash
+streamlit run mvp-medical-app/app.py
+```
+
+Run tests:
+
+```bash
+pytest
+```

--- a/mvp-medical-app/.dockerignore
+++ b/mvp-medical-app/.dockerignore
@@ -1,0 +1,10 @@
+.venv
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+.git
+.gitignore
+.dockerignore
+README.md

--- a/mvp-medical-app/Dockerfile
+++ b/mvp-medical-app/Dockerfile
@@ -1,0 +1,30 @@
+# ========================================
+# Stage 1: Builder
+# ========================================
+FROM python:3.11-slim as builder
+
+RUN pip install uv
+WORKDIR /app
+COPY requirements.txt .
+RUN uv pip install --no-cache -r requirements.txt
+
+RUN echo "import antspynet; antspynet.utilities.get_pretrained_network('brainExtraction')" > preload_models.py
+RUN python preload_models.py
+
+# ========================================
+# Stage 2: Final
+# ========================================
+FROM python:3.11-slim
+WORKDIR /app
+RUN addgroup --system appuser && adduser --system --no-create-home appuser
+USER appuser
+COPY --from=builder /app /app
+COPY --from=builder /root/.antspynet /home/appuser/.antspynet
+COPY --chown=appuser:appuser modules/ ./modules/
+COPY --chown=appuser:appuser pages/ ./pages/
+COPY --chown=appuser:appuser app.py .
+EXPOSE 8501
+ENV STREAMLIT_SERVER_PORT=8501
+ENV STREAMLIT_SERVER_HEADLESS=true
+ENV ANTSPYNET_CACHE_DIRECTORY=/home/appuser/.antspynet
+CMD ["streamlit", "run", "app.py"]

--- a/mvp-medical-app/app.py
+++ b/mvp-medical-app/app.py
@@ -1,0 +1,6 @@
+import streamlit as st
+
+st.set_page_config(page_title="Medical Image Analyzer")
+
+st.title("Medical Image Analyzer")
+st.write("Select a page from the sidebar.")

--- a/mvp-medical-app/modules/image_analyzer.py
+++ b/mvp-medical-app/modules/image_analyzer.py
@@ -1,0 +1,19 @@
+import tempfile
+import ants
+from antspynet.utilities import brain_extraction
+
+
+def analyze_image(image_bytes):
+    """Analyze an uploaded image and return segmentation results."""
+    with tempfile.NamedTemporaryFile(suffix=".nii") as tmp:
+        tmp.write(image_bytes)
+        tmp.flush()
+        image = ants.image_read(tmp.name, pixeltype="float")
+
+    probability_mask = brain_extraction(image, modality="t1")
+    mask = ants.threshold_image(probability_mask, 0.5, 1)
+    return {
+        "original_image": image,
+        "segmentation_mask": mask,
+        "probability_mask": probability_mask,
+    }

--- a/mvp-medical-app/modules/report_generator.py
+++ b/mvp-medical-app/modules/report_generator.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from PIL import Image
+import google.generativeai as genai
+import io
+
+
+class LesionFinding(BaseModel):
+    is_finding_present: bool = Field(description="Whether a lesion is present")
+    finding_summary: Optional[str] = Field(description="Short summary")
+    detailed_description: Optional[str] = Field(description="Detailed description")
+    confidence_score: Optional[float] = Field(description="Confidence 0-1")
+    anatomical_location: Optional[str] = Field(description="Approximate location")
+
+
+def generate_structured_report(original_image, probability_mask, api_key):
+    """Generate a structured report using Gemini."""
+    genai.configure(api_key=api_key)
+
+    original_pil = Image.fromarray(original_image.numpy().astype("uint8"))
+    mask_pil = Image.fromarray((probability_mask.numpy() * 255).astype("uint8"))
+
+    generation_config = genai.GenerationConfig(
+        response_mime_type="application/json",
+        response_schema=LesionFinding,
+    )
+    model = genai.GenerativeModel(
+        model_name="gemini-1.5-pro-latest",
+        generation_config=generation_config,
+    )
+
+    prompt = (
+        "You are a medical imaging assistant. "
+        "Analyze the provided MRI and probability mask and return JSON report."
+    )
+
+    response = model.generate_content([prompt, original_pil, mask_pil])
+    try:
+        return LesionFinding.model_validate_json(response.text)
+    except Exception:
+        return None

--- a/mvp-medical-app/pages/1_Image_Analysis.py
+++ b/mvp-medical-app/pages/1_Image_Analysis.py
@@ -1,0 +1,43 @@
+import streamlit as st
+from modules.image_analyzer import analyze_image
+from modules.report_generator import generate_structured_report
+import os
+
+
+@st.cache_resource
+def cached_analyze(data: bytes):
+    return analyze_image(data)
+
+
+@st.cache_resource
+def cached_report(orig, prob, key):
+    return generate_structured_report(orig, prob, key)
+
+st.set_page_config(page_title="Image Analysis")
+
+st.title("Upload Medical Image")
+
+uploaded_file = st.file_uploader("Upload image", type=["nii", "nii.gz", "png", "jpg"])
+
+if uploaded_file:
+    with st.spinner("Analyzing image..."):
+        results = cached_analyze(uploaded_file.getvalue())
+
+    st.success("Analysis complete")
+
+    col1, col2 = st.columns(2)
+    col1.image(results["original_image"].numpy(), caption="Original")
+    col2.image(results["segmentation_mask"].numpy(), caption="Mask")
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if api_key:
+        with st.spinner("Generating report..."):
+            report = cached_report(
+                results["original_image"],
+                results["probability_mask"],
+                api_key,
+            )
+        if report:
+            st.json(report.model_dump())
+    else:
+        st.warning("GEMINI_API_KEY not set")

--- a/mvp-medical-app/requirements.txt
+++ b/mvp-medical-app/requirements.txt
@@ -1,0 +1,6 @@
+streamlit==1.35.0
+google-generativeai==0.7.1
+antspyx==0.4.3
+antspynet==1.0.3
+tensorflow==2.16.1
+pydantic==2.7.4

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -1,0 +1,26 @@
+import sys
+import os
+from unittest import mock
+
+# Patch heavy modules before import
+sys.modules['ants'] = mock.Mock()
+sys.modules['antspynet'] = mock.Mock()
+sys.modules['antspynet.utilities'] = mock.Mock()
+
+sys.path.insert(0, os.path.abspath('mvp-medical-app'))
+from modules import image_analyzer
+
+
+def test_analyze_image_calls_brain_extraction(tmp_path):
+    data = b'123'
+    with mock.patch.object(image_analyzer, 'ants') as ants_mock, \
+         mock.patch.object(image_analyzer, 'brain_extraction') as brain_extraction_mock, \
+         mock.patch.object(image_analyzer.ants, 'threshold_image') as threshold_mock:
+        ants_mock.image_read.return_value = 'image'
+        brain_extraction_mock.return_value = 'prob'
+        threshold_mock.return_value = 'mask'
+        result = image_analyzer.analyze_image(data)
+        assert result['original_image'] == 'image'
+        assert result['probability_mask'] == 'prob'
+        assert result['segmentation_mask'] == 'mask'
+        brain_extraction_mock.assert_called_once_with('image', modality='t1')

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,32 @@
+import sys
+import os
+from unittest import mock
+
+# Patch heavy modules before import
+sys.modules['google'] = mock.Mock()
+sys.modules['google.generativeai'] = mock.Mock()
+sys.modules['PIL'] = mock.Mock()
+sys.modules['PIL.Image'] = mock.Mock()
+sys.modules['PIL'].Image = mock.Mock()
+
+sys.path.insert(0, os.path.abspath('mvp-medical-app'))
+from modules import report_generator
+
+
+def test_generate_structured_report_uses_api_key():
+    genai_mock = report_generator.genai
+    model_mock = mock.Mock()
+    genai_mock.GenerationConfig.return_value = 'cfg'
+    genai_mock.GenerativeModel.return_value = model_mock
+    model_mock.generate_content.return_value.text = '{"is_finding_present": false}'
+    report_generator.Image.fromarray.return_value = 'img'
+    img_arr = mock.Mock(); img_arr.astype.return_value = []
+    img = mock.Mock(); img.numpy.return_value = img_arr
+    prob_arr = mock.MagicMock()
+    prob_arr.__mul__.return_value = prob_arr
+    prob_arr.astype.return_value = []
+    prob = mock.Mock(); prob.numpy.return_value = prob_arr
+    with mock.patch.object(report_generator.LesionFinding, 'model_validate_json', return_value={'ok': True}):
+        result = report_generator.generate_structured_report(img, prob, 'key')
+    genai_mock.configure.assert_called_once_with(api_key='key')
+    assert result == {'ok': True}


### PR DESCRIPTION
## Summary
- implement cached image analysis and report generation
- document local development and testing steps
- create unit tests for analyzer and report modules
- ignore virtualenv and cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685795773dd08333a3b212dc7360238a