### PR TITLE
Add disclaimer to UI and docs

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,3 +6,4 @@
 - Implemented caching and layout improvements for image analysis page.
 - Added unit tests for analysis and report modules.
 - Added updated development plan and adjusted documentation.
+- Added disclaimer to image analysis page and README.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ The project follows the plan outlined in `Kyotoyama_Medical_Image_Analyzer最新
 The application allows users to upload medical images, perform segmentation with ANTsPyNet,
 and generate a structured report using the Gemini API.
 
+## Disclaimer
+
+This project provides an experimental AI assistant for drafting radiology reports.
+Generated results may contain inaccuracies and must not be used for final medical
+diagnosis. Always verify and edit the output with a qualified professional.
+
 ## Development
 
 Create a Python 3.11 virtual environment and install dependencies:

--- a/mvp-medical-app/pages/1_Image_Analysis.py
+++ b/mvp-medical-app/pages/1_Image_Analysis.py
@@ -16,6 +16,10 @@ def cached_report(orig, prob, key):
 st.set_page_config(page_title="Image Analysis")
 
 st.title("Upload Medical Image")
+st.info(
+    "This tool is an experimental AI assistant for drafting radiology reports. "
+    "Results may contain inaccuracies and should not be used for final diagnosis."
+)
 
 uploaded_file = st.file_uploader("Upload image", type=["nii", "nii.gz", "png", "jpg"])
 


### PR DESCRIPTION
## Summary
- show experimental use disclaimer in Image Analysis page
- document limitations in README
- log progress update

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685805644728833384a81a3def0b652c