### PR TITLE
Add patient info masking utility

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,3 +9,4 @@
 - Added disclaimer to image analysis page and README.
 - Switched report generation to GPT-4.1mini via OpenAI API, updating tests and docs.
 - Implemented overlay PNG output utility and added Pillow dependency.
+- Implemented patient info masking utility with corresponding unit test.

--- a/mvp-medical-app/modules/image_analyzer.py
+++ b/mvp-medical-app/modules/image_analyzer.py
@@ -36,3 +36,19 @@ def save_overlay_png(original_image, segmentation_mask, output_path, color=(255,
     """Save an overlay PNG image combining original and mask."""
     overlay = create_overlay_image(original_image, segmentation_mask, color, alpha)
     overlay.save(output_path, format="PNG")
+
+
+
+def mask_patient_info(image, height_ratio=0.05):
+    """Return a copy of the image with the top portion masked.
+
+    This performs a simple black-out of the specified fraction of
+    the image height to obscure burned-in patient identifiers.
+    """
+    arr = image.numpy().copy()
+    mask_height = max(1, int(arr.shape[0] * height_ratio))
+    if arr.ndim == 3:
+        arr[:mask_height, :, :] = 0
+    else:
+        arr[:mask_height, :] = 0
+    return ants.from_numpy(arr, origin=image.origin, spacing=image.spacing, direction=image.direction)

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from unittest import mock
+import numpy as np
 
 # Patch heavy modules before import
 sys.modules['ants'] = mock.Mock()
@@ -33,3 +34,19 @@ def test_save_overlay_png_uses_pil(tmp_path):
         image_analyzer.save_overlay_png('img', 'mask', out)
         create_mock.assert_called_once_with('img', 'mask', (255, 0, 0), 0.3)
         overlay_img.save.assert_called_once_with(out, format='PNG')
+
+
+def test_mask_patient_info_zeroes_top():
+    img = mock.Mock()
+    arr = np.ones((10, 10))
+    img.numpy.return_value = arr
+    img.origin = 'o'
+    img.spacing = 's'
+    img.direction = 'd'
+    with mock.patch.object(image_analyzer.ants, "from_numpy", return_value="new") as fn:
+        result = image_analyzer.mask_patient_info(img, 0.2)
+        modified = fn.call_args[0][0]
+    assert np.all(modified[:2] == 0)
+    assert np.all(modified[2:] == 1)
+    fn.assert_called_once()
+    assert result == 'new'


### PR DESCRIPTION
## Summary
- add `mask_patient_info` helper to anonymize burned-in data
- test masking logic and update progress log

## Testing
- `pip install numpy pydantic pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858091d383883338a431332f1cc8f34