### PR TITLE
Integrate patient info masking into GPT reporting

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,3 +10,4 @@
 - Switched report generation to GPT-4.1mini via OpenAI API, updating tests and docs.
 - Implemented overlay PNG output utility and added Pillow dependency.
 - Implemented patient info masking utility with corresponding unit test.
+- Integrated patient info masking into GPT report generation and updated tests.

--- a/mvp-medical-app/modules/report_generator.py
+++ b/mvp-medical-app/modules/report_generator.py
@@ -4,6 +4,7 @@ from PIL import Image
 import openai
 import io
 import base64
+from modules.image_analyzer import mask_patient_info
 
 
 class LesionFinding(BaseModel):
@@ -24,7 +25,8 @@ def generate_structured_report(original_image, probability_mask, api_key):
     """Generate a structured report using GPT-4.1mini."""
     client = openai.OpenAI(api_key=api_key)
 
-    original_pil = Image.fromarray(original_image.numpy().astype("uint8"))
+    masked = mask_patient_info(original_image)
+    original_pil = Image.fromarray(masked.numpy().astype("uint8"))
     mask_pil = Image.fromarray((probability_mask.numpy() * 255).astype("uint8"))
 
     orig_url = _image_to_data_url(original_pil)

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -7,6 +7,9 @@ sys.modules['openai'] = mock.Mock()
 sys.modules['PIL'] = mock.Mock()
 sys.modules['PIL.Image'] = mock.Mock()
 sys.modules['PIL'].Image = mock.Mock()
+sys.modules['ants'] = mock.Mock()
+sys.modules['antspynet'] = mock.Mock()
+sys.modules['antspynet.utilities'] = mock.Mock()
 
 sys.path.insert(0, os.path.abspath('mvp-medical-app'))
 from modules import report_generator
@@ -29,8 +32,10 @@ def test_generate_structured_report_uses_api_key():
     prob_arr.__mul__.return_value = prob_arr
     prob_arr.astype.return_value = []
     prob = mock.Mock(); prob.numpy.return_value = prob_arr
-    with mock.patch.object(report_generator.LesionFinding, 'model_validate_json', return_value={'ok': True}):
+    with mock.patch.object(report_generator, 'mask_patient_info', return_value=img) as mask_mock, \
+         mock.patch.object(report_generator.LesionFinding, 'model_validate_json', return_value={'ok': True}):
         result = report_generator.generate_structured_report(img, prob, 'key')
+    mask_mock.assert_called_once_with(img)
     openai_mock.OpenAI.assert_called_once_with(api_key='key')
     completion_mock.assert_called_once()
     assert result == {'ok': True}


### PR DESCRIPTION
## Summary
- apply patient masking before calling GPT report generation
- patch test to check mask use
- log progress

## Testing
- `pip install numpy pydantic pillow openai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580ad32a788333ada9f2622216289f