### PR TITLE
Add comment system and tests

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,3 +11,4 @@
 - Implemented overlay PNG output utility and added Pillow dependency.
 - Implemented patient info masking utility with corresponding unit test.
 - Integrated patient info masking into GPT report generation and updated tests.
+- Added SQLite-based comment feature with new Streamlit page and tests.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains an MVP for a Streamlit-based medical image analysis app
 The project follows the plan outlined in `Kyotoyama_Medical_Image_Analyzer最新版MVP設計・進捗管理.md`.
 
 The application allows users to upload medical images, perform segmentation with ANTsPyNet,
-and generate a structured report using the GPT-4.1mini API.
+generate a structured report using the GPT-4.1mini API, and store simple image comments.
 
 ## Disclaimer
 
@@ -27,6 +27,8 @@ Run the Streamlit app:
 ```bash
 streamlit run mvp-medical-app/app.py
 ```
+
+Set `COMMENT_DB_PATH` to control where comments are stored (defaults to `comments.db`).
 
 Run tests:
 

--- a/mvp-medical-app/modules/__init__.py
+++ b/mvp-medical-app/modules/__init__.py
@@ -1,0 +1,7 @@
+"""Utility modules for the Streamlit MVP."""
+
+__all__ = [
+    'image_analyzer',
+    'report_generator',
+    'comments',
+]

--- a/mvp-medical-app/modules/comments.py
+++ b/mvp-medical-app/modules/comments.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Dict, Optional
+
+
+def _ensure_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            image_name TEXT NOT NULL,
+            text TEXT NOT NULL
+        )
+        """
+    )
+    return conn
+
+
+def add_comment(db_path: str | Path, image_name: str, text: str) -> None:
+    """Insert a new comment into the database."""
+    with _ensure_db(Path(db_path)) as conn:
+        conn.execute(
+            "INSERT INTO comments (image_name, text) VALUES (?, ?)",
+            (image_name, text),
+        )
+        conn.commit()
+
+
+def list_comments(db_path: str | Path, image_name: Optional[str] = None) -> List[Dict[str, str]]:
+    """Return all comments or those for a given image."""
+    with _ensure_db(Path(db_path)) as conn:
+        if image_name:
+            cur = conn.execute(
+                "SELECT id, image_name, text FROM comments WHERE image_name = ?",
+                (image_name,),
+            )
+        else:
+            cur = conn.execute("SELECT id, image_name, text FROM comments")
+        rows = cur.fetchall()
+    return [
+        {"id": r[0], "image_name": r[1], "text": r[2]} for r in rows
+    ]

--- a/mvp-medical-app/pages/1_Image_Analysis.py
+++ b/mvp-medical-app/pages/1_Image_Analysis.py
@@ -1,7 +1,10 @@
 import streamlit as st
 from modules.image_analyzer import analyze_image
 from modules.report_generator import generate_structured_report
+from modules.comments import add_comment
 import os
+
+DB_PATH = os.environ.get("COMMENT_DB_PATH", "comments.db")
 
 
 @st.cache_resource
@@ -45,3 +48,9 @@ if uploaded_file:
             st.json(report.model_dump())
     else:
         st.warning("GEMINI_API_KEY not set")
+
+    st.subheader("Add Comment")
+    comment = st.text_area("Comment")
+    if st.button("Save Comment"):
+        add_comment(DB_PATH, uploaded_file.name, comment)
+        st.success("Comment saved")

--- a/mvp-medical-app/pages/2_Comments.py
+++ b/mvp-medical-app/pages/2_Comments.py
@@ -1,0 +1,24 @@
+import os
+import streamlit as st
+from modules.comments import add_comment, list_comments
+
+DB_PATH = os.environ.get("COMMENT_DB_PATH", "comments.db")
+
+st.set_page_config(page_title="Comments")
+
+st.title("Image Comments")
+
+image_name = st.text_input("Image identifier")
+comment_text = st.text_area("Comment")
+
+if st.button("Save Comment"):
+    if not image_name or not comment_text:
+        st.error("Provide image identifier and comment text")
+    else:
+        add_comment(DB_PATH, image_name, comment_text)
+        st.success("Comment saved")
+
+st.subheader("Stored Comments")
+comments = list_comments(DB_PATH, image_name if image_name else None)
+for c in comments:
+    st.markdown(f"**{c['image_name']}**: {c['text']}")

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -1,0 +1,14 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath('mvp-medical-app'))
+from modules import comments
+
+
+def test_add_and_list_comments(tmp_path):
+    db = tmp_path / "c.db"
+    comments.add_comment(db, "img1", "a")
+    comments.add_comment(db, "img1", "b")
+    rows = comments.list_comments(db, "img1")
+    assert len(rows) == 2
+    assert rows[0]["text"] == "a"


### PR DESCRIPTION
## Summary
- implement SQLite-based comment storage
- provide comments module with helper functions
- add comments page and integrate into analysis page
- describe comment DB env var in README
- log progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a0a2a1c08333a8e333bcf6624fcf