### PR TITLE
Implement GPT OCR feature

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -12,3 +12,4 @@
 - Implemented patient info masking utility with corresponding unit test.
 - Integrated patient info masking into GPT report generation and updated tests.
 - Added SQLite-based comment feature with new Streamlit page and tests.
+- Added GPT-based OCR feature with caching and tests.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This project provides an experimental AI assistant for drafting radiology report
 Generated results may contain inaccuracies and must not be used for final medical
 diagnosis. Always verify and edit the output with a qualified professional.
 
+The app can also extract burned-in text from uploaded images using GPT-4.1mini OCR.
+
 ## Development
 
 Create a Python 3.11 virtual environment and install dependencies:

--- a/mvp-medical-app/modules/ocr.py
+++ b/mvp-medical-app/modules/ocr.py
@@ -1,0 +1,38 @@
+from PIL import Image
+import openai
+import io
+import base64
+from modules.image_analyzer import mask_patient_info
+
+
+def _image_to_data_url(image: Image.Image) -> str:
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def extract_burned_in_text(image, api_key: str) -> str | None:
+    """Extract burned-in text from an image using GPT-4.1mini OCR."""
+    client = openai.OpenAI(api_key=api_key)
+
+    masked = mask_patient_info(image)
+    pil = Image.fromarray(masked.numpy().astype("uint8"))
+    img_url = _image_to_data_url(pil)
+
+    prompt = (
+        "You are an OCR assistant. "
+        "Return all visible text from the provided medical image as plain text."
+    )
+
+    response = client.chat.completions.create(
+        model="gpt-4.1mini",
+        messages=[
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": [{"type": "image_url", "image_url": {"url": img_url}}]},
+        ],
+    )
+
+    try:
+        return response.choices[0].message.content
+    except Exception:
+        return None

--- a/mvp-medical-app/pages/1_Image_Analysis.py
+++ b/mvp-medical-app/pages/1_Image_Analysis.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from modules.image_analyzer import analyze_image
 from modules.report_generator import generate_structured_report
+from modules.ocr import extract_burned_in_text
 from modules.comments import add_comment
 import os
 
@@ -15,6 +16,11 @@ def cached_analyze(data: bytes):
 @st.cache_resource
 def cached_report(orig, prob, key):
     return generate_structured_report(orig, prob, key)
+
+
+@st.cache_resource
+def cached_ocr(image, key):
+    return extract_burned_in_text(image, key)
 
 st.set_page_config(page_title="Image Analysis")
 
@@ -46,6 +52,12 @@ if uploaded_file:
             )
         if report:
             st.json(report.model_dump())
+
+        with st.spinner("Extracting burned-in text..."):
+            text = cached_ocr(results["original_image"], api_key)
+        if text:
+            st.subheader("Burned-in Text")
+            st.text(text)
     else:
         st.warning("GEMINI_API_KEY not set")
 

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,27 @@
+import sys
+import os
+from unittest import mock
+
+sys.modules['openai'] = mock.Mock()
+sys.modules['PIL'] = mock.Mock()
+sys.modules['PIL.Image'] = mock.Mock()
+sys.modules['PIL'].Image = mock.Mock()
+
+sys.path.insert(0, os.path.abspath('mvp-medical-app'))
+from modules import ocr
+
+
+def test_extract_burned_in_text_calls_api():
+    client_mock = ocr.openai.OpenAI.return_value
+    completion_mock = client_mock.chat.completions.create
+    completion_mock.return_value.choices = [mock.Mock(message=mock.Mock(content='TXT'))]
+
+    img_mock = mock.Mock()
+    img_mock.numpy.return_value = mock.Mock(astype=lambda t: [])
+
+    with mock.patch.object(ocr, 'mask_patient_info', return_value=img_mock):
+        result = ocr.extract_burned_in_text(img_mock, 'k')
+
+    ocr.openai.OpenAI.assert_called_once_with(api_key='k')
+    completion_mock.assert_called_once()
+    assert result == 'TXT'


### PR DESCRIPTION
## Summary
- add GPT-based OCR module
- show burned-in text on image analysis page
- document the OCR feature in README
- track progress in PROGRESS log
- add unit test for OCR module

## Testing
- `pip install -q numpy pydantic pillow openai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a253834c833398642bd22d9a7580