### PR TITLE
Enable overlay download

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -13,3 +13,4 @@
 - Integrated patient info masking into GPT report generation and updated tests.
 - Added SQLite-based comment feature with new Streamlit page and tests.
 - Added GPT-based OCR feature with caching and tests.
+- Enabled overlay PNG download in the image analysis page and documented usage.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Generated results may contain inaccuracies and must not be used for final medica
 diagnosis. Always verify and edit the output with a qualified professional.
 
 The app can also extract burned-in text from uploaded images using GPT-4.1mini OCR.
+Overlay images combining segmentation results with the original can be downloaded as PNG files.
 
 ## Development
 

--- a/mvp-medical-app/modules/image_analyzer.py
+++ b/mvp-medical-app/modules/image_analyzer.py
@@ -1,4 +1,5 @@
 import tempfile
+import io
 import numpy as np
 from PIL import Image
 import ants
@@ -36,6 +37,14 @@ def save_overlay_png(original_image, segmentation_mask, output_path, color=(255,
     """Save an overlay PNG image combining original and mask."""
     overlay = create_overlay_image(original_image, segmentation_mask, color, alpha)
     overlay.save(output_path, format="PNG")
+
+
+def overlay_png_bytes(original_image, segmentation_mask, color=(255, 0, 0), alpha=0.3) -> bytes:
+    """Return overlay image bytes in PNG format."""
+    overlay = create_overlay_image(original_image, segmentation_mask, color, alpha)
+    buf = io.BytesIO()
+    overlay.save(buf, format="PNG")
+    return buf.getvalue()
 
 
 

--- a/mvp-medical-app/pages/1_Image_Analysis.py
+++ b/mvp-medical-app/pages/1_Image_Analysis.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from modules.image_analyzer import analyze_image
+from modules.image_analyzer import analyze_image, overlay_png_bytes
 from modules.report_generator import generate_structured_report
 from modules.ocr import extract_burned_in_text
 from modules.comments import add_comment
@@ -41,6 +41,17 @@ if uploaded_file:
     col1, col2 = st.columns(2)
     col1.image(results["original_image"].numpy(), caption="Original")
     col2.image(results["segmentation_mask"].numpy(), caption="Mask")
+
+    overlay_bytes = overlay_png_bytes(
+        results["original_image"],
+        results["segmentation_mask"],
+    )
+    st.download_button(
+        "Download Overlay PNG",
+        overlay_bytes,
+        file_name=f"{uploaded_file.name}_overlay.png",
+        mime="image/png",
+    )
 
     api_key = os.environ.get("GEMINI_API_KEY")
     if api_key:

--- a/tests/test_image_analyzer.py
+++ b/tests/test_image_analyzer.py
@@ -36,6 +36,15 @@ def test_save_overlay_png_uses_pil(tmp_path):
         overlay_img.save.assert_called_once_with(out, format='PNG')
 
 
+def test_overlay_png_bytes_returns_bytes():
+    overlay_img = mock.Mock()
+    with mock.patch.object(image_analyzer, 'create_overlay_image', return_value=overlay_img) as create_mock:
+        overlay_img.save.side_effect = lambda buf, format=None: buf.write(b'data')
+        result = image_analyzer.overlay_png_bytes('img', 'mask')
+        create_mock.assert_called_once_with('img', 'mask', (255, 0, 0), 0.3)
+        assert result == b'data'
+
+
 def test_mask_patient_info_zeroes_top():
     img = mock.Mock()
     arr = np.ones((10, 10))


### PR DESCRIPTION
## Summary
- allow overlay PNG download in image analysis page
- provide helper to return overlay image bytes
- update README instructions
- track progress in PROGRESS.md
- test overlay byte helper

## Testing
- `pip install -q numpy pydantic pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858be1e74048333a5366c73a67b5842