### PR TITLE
Add comment editing support

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,3 +14,4 @@
 - Added SQLite-based comment feature with new Streamlit page and tests.
 - Added GPT-based OCR feature with caching and tests.
 - Enabled overlay PNG download in the image analysis page and documented usage.
+- Added comment editing support with update function, UI changes, and tests.

--- a/mvp-medical-app/modules/comments.py
+++ b/mvp-medical-app/modules/comments.py
@@ -43,3 +43,13 @@ def list_comments(db_path: str | Path, image_name: Optional[str] = None) -> List
     return [
         {"id": r[0], "image_name": r[1], "text": r[2]} for r in rows
     ]
+
+
+def update_comment(db_path: str | Path, comment_id: int, new_text: str) -> None:
+    """Update the text of an existing comment."""
+    with _ensure_db(Path(db_path)) as conn:
+        conn.execute(
+            "UPDATE comments SET text = ? WHERE id = ?",
+            (new_text, comment_id),
+        )
+        conn.commit()

--- a/mvp-medical-app/pages/2_Comments.py
+++ b/mvp-medical-app/pages/2_Comments.py
@@ -1,6 +1,6 @@
 import os
 import streamlit as st
-from modules.comments import add_comment, list_comments
+from modules.comments import add_comment, list_comments, update_comment
 
 DB_PATH = os.environ.get("COMMENT_DB_PATH", "comments.db")
 
@@ -22,3 +22,12 @@ st.subheader("Stored Comments")
 comments = list_comments(DB_PATH, image_name if image_name else None)
 for c in comments:
     st.markdown(f"**{c['image_name']}**: {c['text']}")
+
+st.subheader("Edit Comment")
+comment_ids = [str(c["id"]) for c in comments]
+if comment_ids:
+    selected_id = st.selectbox("Comment ID", comment_ids)
+    new_text = st.text_area("New text", key="edit")
+    if st.button("Update Comment"):
+        update_comment(DB_PATH, int(selected_id), new_text)
+        st.success("Comment updated")

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -12,3 +12,12 @@ def test_add_and_list_comments(tmp_path):
     rows = comments.list_comments(db, "img1")
     assert len(rows) == 2
     assert rows[0]["text"] == "a"
+
+
+def test_update_comment(tmp_path):
+    db = tmp_path / "c.db"
+    comments.add_comment(db, "img", "old")
+    cid = comments.list_comments(db)[0]["id"]
+    comments.update_comment(db, cid, "new")
+    row = comments.list_comments(db)[0]
+    assert row["text"] == "new"


### PR DESCRIPTION
## Summary
- support editing comments in database
- expose editing UI on comments page
- test comment update function
- document progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858cf8bf45c8333b09e164bdf3a39f7