### PR TITLE
Add DICOM utilities

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,3 +15,4 @@
 - Added GPT-based OCR feature with caching and tests.
 - Enabled overlay PNG download in the image analysis page and documented usage.
 - Added comment editing support with update function, UI changes, and tests.
+- Added DICOM series load/save utilities with tests.

--- a/mvp-medical-app/modules/__init__.py
+++ b/mvp-medical-app/modules/__init__.py
@@ -4,4 +4,6 @@ __all__ = [
     'image_analyzer',
     'report_generator',
     'comments',
+    'ocr',
+    'dicom',
 ]

--- a/mvp-medical-app/modules/dicom.py
+++ b/mvp-medical-app/modules/dicom.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pydicom
+from pydicom.dataset import FileDataset
+
+
+def load_series(directory: str | Path) -> List[FileDataset]:
+    """Load all DICOM files in a directory."""
+    path = Path(directory)
+    datasets = []
+    for f in sorted(path.glob("*.dcm")):
+        datasets.append(pydicom.dcmread(str(f)))
+    return datasets
+
+
+def save_series(directory: str | Path, datasets: List[FileDataset]) -> None:
+    """Save a list of DICOM datasets into a directory."""
+    dest = Path(directory)
+    dest.mkdir(parents=True, exist_ok=True)
+    for i, ds in enumerate(datasets):
+        ds.save_as(dest / f"{i:04d}.dcm")
+
+

--- a/mvp-medical-app/requirements.txt
+++ b/mvp-medical-app/requirements.txt
@@ -5,3 +5,5 @@ antspynet==1.0.3
 tensorflow==2.16.1
 pydantic==2.7.4
 pillow==10.3.0
+pydicom==2.4.4
+pynetdicom==2.0.2

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,0 +1,35 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath('mvp-medical-app'))
+from modules import dicom
+import pydicom
+from pydicom.dataset import FileDataset, FileMetaDataset
+
+
+def _make_dataset(patient_name: str) -> FileDataset:
+    meta = FileMetaDataset()
+    ds = FileDataset('test', {}, file_meta=meta, preamble=b'\0' * 128)
+    ds.is_little_endian = True
+    ds.is_implicit_VR = True
+    ds.PatientName = patient_name
+    return ds
+
+
+def test_load_and_save_series(tmp_path):
+    src = tmp_path / 'src'
+    src.mkdir()
+    ds = _make_dataset('Alice')
+    ds.save_as(src / '1.dcm')
+
+    loaded = dicom.load_series(src)
+    assert len(loaded) == 1
+    assert loaded[0].PatientName == 'Alice'
+
+    dest = tmp_path / 'dest'
+    dicom.save_series(dest, loaded)
+    saved = list(dest.glob('*.dcm'))
+    assert len(saved) == 1
+    new_ds = pydicom.dcmread(saved[0])
+    assert new_ds.PatientName == 'Alice'
+


### PR DESCRIPTION
## Summary
- implement simple DICOM series load/save module
- expose new module through `__all__`
- include pydicom and pynetdicom in requirements
- test DICOM utilities
- document progress

## Testing
- `pip install numpy pydantic==2.7.4 pydicom==2.4.4 pynetdicom==2.0.2 pillow==10.3.0 streamlit==1.35.0 openai==1.30.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ee4b01a88333ace86e9d1f2d5055